### PR TITLE
fix(pyenv): ignore commented out `.python-version` entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+### Fixed
+- Ignore commented out .python-version entries (@scop)
 
 ## 0.1.0 - 2020-12-16
 ### Added

--- a/src/venvrun.py
+++ b/src/venvrun.py
@@ -2,6 +2,7 @@ from argparse import ArgumentParser, REMAINDER
 from glob import glob
 import os.path
 import platform
+import re
 import subprocess
 import sys
 
@@ -19,10 +20,12 @@ def guess():
     exes.append(os.path.join(os.path.curdir, *pypath))
     try:
         with open('.python-version', 'r') as f:
-            proc = subprocess.run(
-                ('pyenv', 'prefix', f.readline().strip()),
-                stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
-            exes.append(os.path.join(proc.stdout.decode().strip(), *pypath))
+            for prefix in (x.strip() for x in f if not re.match(r'\s*#', x)):
+                proc = subprocess.run(
+                    ('pyenv', 'prefix', prefix),
+                    stdout=subprocess.PIPE, stderr=subprocess.DEVNULL)
+                exes.append(os.path.join(proc.stdout.decode().strip(), *pypath))
+                break
     except FileNotFoundError:
         pass
 

--- a/tests/fixture/.python-version
+++ b/tests/fixture/.python-version
@@ -1,3 +1,4 @@
+#commented-out
 venv-run-testsuite
 some-other-ignored-venv
 3.9.1


### PR DESCRIPTION
Refs https://github.com/pyenv/pyenv/pull/1866