### PR TITLE
Canonicalize and deduplicate guesses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 ### Fixed
 - Ignore commented out .python-version entries (@scop)
+- Canonicalize, absolutize, and deduplicate list of found env dirs (@scop)
 
 ## 0.1.0 - 2020-12-16
 ### Added

--- a/src/venvrun.py
+++ b/src/venvrun.py
@@ -31,7 +31,10 @@ def guess():
         pass
 
     venvs = OrderedDict(
-        (os.path.dirname(os.path.dirname(exe)), True) for exe in exes
+        # Absolutize, normalize, and canonicalize for deduplication
+        (os.path.realpath(os.path.abspath(
+            os.path.dirname(os.path.dirname(exe)))), True)
+        for exe in exes
         if os.access(exe, os.X_OK)
     )
 

--- a/src/venvrun.py
+++ b/src/venvrun.py
@@ -1,4 +1,5 @@
 from argparse import ArgumentParser, REMAINDER
+from collections import OrderedDict
 from glob import glob
 import os.path
 import platform
@@ -29,12 +30,12 @@ def guess():
     except FileNotFoundError:
         pass
 
-    venvs = [
-        os.path.dirname(os.path.dirname(exe)) for exe in exes
+    venvs = OrderedDict(
+        (os.path.dirname(os.path.dirname(exe)), True) for exe in exes
         if os.access(exe, os.X_OK)
-    ]
+    )
 
-    return venvs
+    return venvs.keys()
 
 
 def run():

--- a/tests/test_venvrun.py
+++ b/tests/test_venvrun.py
@@ -1,5 +1,6 @@
 import os
 import sys
+import tempfile
 import unittest
 from subprocess import run as real_subprocess_run
 from unittest.mock import patch
@@ -56,3 +57,26 @@ class VenvRunTest(unittest.TestCase):
                             'venv', '.venv', os.curdir
                     ))
             )
+
+    def testGuessDedupeSymlink(self):
+        with tempfile.TemporaryDirectory(prefix="venv-run") as tempdir:
+            symlink = os.path.join(tempdir, "venv")
+            os.symlink(os.path.join(os.getcwd(), "venv"), symlink)
+
+            def mock_run(*args, **kwargs):
+                if args[0] == ('pyenv', 'prefix', 'venv-run-testsuite'):
+                    return real_subprocess_run(
+                        ('echo', symlink), **kwargs)
+                return real_subprocess_run(*args, **kwargs)
+
+            with patch.object(venvrun.platform, "system", return_value='Linux'), \
+                 patch.object(venvrun.subprocess, "run", mock_run):
+                venvs = venvrun.guess()
+                self.assertListEqual(
+                    sorted(venvs),
+                    sorted(
+                        os.path.normpath(os.path.join(os.getcwd(), x))
+                        for x in (
+                                'venv', '.venv', os.curdir
+                        ))
+                )

--- a/tests/test_venvrun.py
+++ b/tests/test_venvrun.py
@@ -31,3 +31,18 @@ class VenvRunTest(unittest.TestCase):
             self.assertListEqual(sorted(venvs), sorted([
                 'venv', '.venv', os.curdir, 'pyenv/path/somewhere'
             ]))
+
+    def testGuessDedupe(self):
+
+        def mock_run(*args, **kwargs):
+            if args[0] == ('pyenv', 'prefix', 'venv-run-testsuite'):
+                return real_subprocess_run(
+                    ('echo', 'venv'), **kwargs)
+            return real_subprocess_run(*args, **kwargs)
+
+        with patch.object(venvrun.platform, "system", return_value='Linux'), \
+             patch.object(venvrun.subprocess, "run", mock_run):
+            venvs = venvrun.guess()
+            self.assertListEqual(sorted(venvs), sorted([
+                'venv', '.venv', os.curdir,
+            ]))

--- a/tests/test_venvrun.py
+++ b/tests/test_venvrun.py
@@ -28,9 +28,14 @@ class VenvRunTest(unittest.TestCase):
         with patch.object(venvrun.platform, "system", return_value='Linux'), \
              patch.object(venvrun.subprocess, "run", mock_run):
             venvs = venvrun.guess()
-            self.assertListEqual(sorted(venvs), sorted([
-                'venv', '.venv', os.curdir, 'pyenv/path/somewhere'
-            ]))
+            self.assertListEqual(
+                sorted(venvs),
+                sorted(
+                    os.path.normpath(os.path.join(os.getcwd(), x))
+                    for x in (
+                            'venv', '.venv', os.curdir, 'pyenv/path/somewhere'
+                    ))
+            )
 
     def testGuessDedupe(self):
 
@@ -43,6 +48,11 @@ class VenvRunTest(unittest.TestCase):
         with patch.object(venvrun.platform, "system", return_value='Linux'), \
              patch.object(venvrun.subprocess, "run", mock_run):
             venvs = venvrun.guess()
-            self.assertListEqual(sorted(venvs), sorted([
-                'venv', '.venv', os.curdir,
-            ]))
+            self.assertListEqual(
+                sorted(venvs),
+                sorted(
+                    os.path.normpath(os.path.join(os.getcwd(), x))
+                    for x in (
+                            'venv', '.venv', os.curdir
+                    ))
+            )


### PR DESCRIPTION
So in (the rare) case we find multiple paths that point to the same venv, don't fail but just use it.