### PR TITLE
fix(guess): return `list` instead of `odict_keys`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-- Nothing yet.
+- Fix subscripted access to guessed venvs return value (@scop)
 
 ## 0.1.1 - 2022-02-28
 ### Fixed

--- a/src/venvrun.py
+++ b/src/venvrun.py
@@ -38,7 +38,7 @@ def guess():
         if os.access(exe, os.X_OK)
     )
 
-    return venvs.keys()
+    return list(venvs.keys())
 
 
 def run():

--- a/tests/test_venvrun.py
+++ b/tests/test_venvrun.py
@@ -29,6 +29,7 @@ class VenvRunTest(unittest.TestCase):
         with patch.object(venvrun.platform, "system", return_value='Linux'), \
              patch.object(venvrun.subprocess, "run", mock_run):
             venvs = venvrun.guess()
+            self.assertTrue(venvs[0], "subscriptability")
             self.assertListEqual(
                 sorted(venvs),
                 sorted(
@@ -49,6 +50,7 @@ class VenvRunTest(unittest.TestCase):
         with patch.object(venvrun.platform, "system", return_value='Linux'), \
              patch.object(venvrun.subprocess, "run", mock_run):
             venvs = venvrun.guess()
+            self.assertTrue(venvs[0], "subscriptability")
             self.assertListEqual(
                 sorted(venvs),
                 sorted(
@@ -72,6 +74,7 @@ class VenvRunTest(unittest.TestCase):
             with patch.object(venvrun.platform, "system", return_value='Linux'), \
                  patch.object(venvrun.subprocess, "run", mock_run):
                 venvs = venvrun.guess()
+                self.assertTrue(venvs[0], "subscriptability")
                 self.assertListEqual(
                     sorted(venvs),
                     sorted(


### PR DESCRIPTION
`run()` uses subscripted access to the return sequence, which doesn't work for `odict_keys`.

Unfortunately this means 0.1.1 is pretty much completely broken. My bad, I only now got to test the whole thing.