### PR TITLE
chore: drop Python < 3.7 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     ],
     package_dir={'': 'src'},
     py_modules=['venvrun'],
-    python_requires='~=3.5',
+    python_requires='~=3.7',
     entry_points={
         'console_scripts': [
             'venv-run = venvrun:run',

--- a/src/venvrun.py
+++ b/src/venvrun.py
@@ -1,5 +1,4 @@
 from argparse import ArgumentParser, REMAINDER
-from collections import OrderedDict
 from glob import glob
 from typing import List
 import os.path
@@ -47,7 +46,7 @@ def guess() -> List[str]:
     except FileNotFoundError:
         pass
 
-    venvs = OrderedDict(
+    venvs = dict(
         # Absolutize, normalize, and canonicalize for deduplication
         (os.path.realpath(os.path.abspath(
             os.path.dirname(os.path.dirname(exe)))), True)


### PR DESCRIPTION
Per https://github.com/guludo/venv-run/pull/18#discussion_r1125548806