### PR TITLE
chore(renovate): fix cron schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -34,7 +34,7 @@
       "matchPackagePatterns": ["(^|/)ruff(-pre-commit)?$"],
       "groupName": "ruff",
       "versioning": "pep440",
-      "schedule": "42 4 * * 5/2"
+      "schedule": "* 4 * * 5/2"
     }
   ]
 }


### PR DESCRIPTION
From https://docs.renovatebot.com/configuration-options/#schedule

> For Cron schedules, you must use the * wildcard for the minutes value,
> as Renovate doesn't support minute granularity.

Closes https://github.com/guludo/venv-run/issues/22